### PR TITLE
Ignore angr run-time database directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 *.nam
 *.til
 .DS_Store
+*_angr_rtdb
+*_angr_rtdb_*


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

angr writes its run-time LMDB database beside the binary it loads unless `RTDB_BASE` points elsewhere, so analysing the fixtures here leaves a `<fixture>_angr_rtdb` directory next to each one. The directory is removed on a clean exit and survives anything else — a kill, an out-of-memory stop, an interrupted sweep. Nothing ignores it:

```
$ git status --porcelain tests/x86_64
?? tests/x86_64/fauxware_angr_rtdb/
$ git check-ignore -v tests/x86_64/fauxware_angr_rtdb
(no .gitignore pattern matches it)
```

They accumulate: one local checkout of this repository used for angr test runs holds 299 of them. Every one is a line of `git status` output that a fixture author has to read past, and a `git add -A` sweeps them into a commit.

### Root cause

The two names angr can give that directory — `<binary>_angr_rtdb` and, when that one is taken, `<binary>_angr_rtdb_<uuid>` — are ignored in angr's own repository and nowhere else. `angr/binaries` has no `.gitignore` entry for either, and it is the repository the directories are actually created in, because it is where the binaries are.

### Fix

Add the same two lines angr's `.gitignore` carries at lines 39-40 to this repository's `.gitignore`:

```
$ git check-ignore -v tests/x86_64/fauxware_angr_rtdb
.gitignore:10:*_angr_rtdb	tests/x86_64/fauxware_angr_rtdb
$ git status --porcelain tests/x86_64
```

It hides the directories rather than stopping angr from creating them; creating them is angr's intended default and is not changed here.

### Testing

`git ls-files | grep -i angr_rtdb` returns nothing on master, so neither pattern can mask a tracked file. Both spellings were checked with `git check-ignore -v` against a directory angr had actually created, one matching `.gitignore:10` and the other `.gitignore:11`. This repository has no suite and no pre-commit configuration, so there is nothing else to run.

Validation: https://github.com/angr/binaries/pull/211#issuecomment-5449512547

session: sharpen
