### PR TITLE
build_notype_import: narrow .dynsym to a symbol table before iterating

### DIFF
--- a/tests_src/ppc64_notype_import/build_notype_import.py
+++ b/tests_src/ppc64_notype_import/build_notype_import.py
@@ -22,6 +22,7 @@ import os
 import shutil
 
 from elftools.elf.elffile import ELFFile
+from elftools.elf.sections import SymbolTableSection
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 TESTS = os.path.join(HERE, "..", "..", "tests", "ppc64")
@@ -39,8 +40,8 @@ def st_info_offsets(path: str, names: tuple[str, ...]) -> dict[str, int]:
     """File offset of each named dynamic symbol's st_info byte."""
     with open(path, "rb") as stream:
         dynsym = ELFFile(stream).get_section_by_name(".dynsym")
-        if dynsym is None:
-            raise SystemExit(f"{path} has no .dynsym")
+        if not isinstance(dynsym, SymbolTableSection):
+            raise SystemExit(f"{path} has no .dynsym symbol table")
         found = {}
         for index, symbol in enumerate(dynsym.iter_symbols()):
             if symbol.name in names:


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

pyright reports one error in `tests_src/ppc64_notype_import/build_notype_import.py`,
the script that builds `tests/ppc64/fauxware_notype_import`:

```text
build_notype_import.py:45 - error: Cannot access attribute "iter_symbols" for class "Section"
    Attribute "iter_symbols" is unknown (reportAttributeAccessIssue)
```

The file is new, so the `angr/mono` badness ratchet scores it against an empty
baseline and fails it.

### Root cause

`ELFFile.get_section_by_name` returns a `Section`, and `iter_symbols` is defined
on `SymbolTableSection`. The existing `if dynsym is None` guard rules out a
missing section but leaves the type as the base `Section`, which has no
`iter_symbols`.

### Fix

Check `isinstance(dynsym, SymbolTableSection)` instead. That is the condition
the loop below actually needs, and a file whose `.dynsym` is not a symbol table
now exits with a message rather than an `AttributeError`.

### Testing

The script still rebuilds the committed `tests/ppc64/fauxware_notype_import`
byte for byte, sha256
`59cadd8413d3f97f2642b89a59851300576fd8b58d8c173f9830111311014b3e`. pyright goes
from one error to none, so badness goes from 0.1449 to 0.0000.

Validation: https://github.com/angr/binaries/pull/221#issuecomment-5470781959

session: sharpen